### PR TITLE
Use CSS for dark mode links

### DIFF
--- a/_sass/skin.scss
+++ b/_sass/skin.scss
@@ -20,7 +20,10 @@ $blk:      #000000;
 
 
 a {
-  color: $dk-grey;
+  @extend .dk-grey-text;
+  body.dk-grey-bg & {
+    @extend .grey-text;
+  }
 }
 
 nav {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -31,7 +31,7 @@ function switchTheme() {
     };
 }
 
-SWITCH.addEventListener("click", () => switchTheme(), false);
+SWITCH.addEventListener("click", switchTheme, false);
 
 
 // **************************************************************************

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -17,17 +17,9 @@ const SWITCH = document.querySelector('.theme');
 function switchTheme() {
     if (BODY.classList.contains("grey-bg")) {
         BODY.classList.replace("grey-bg", "dk-grey-bg");
-        // This is the only way I could get links to be syled. links.classList.add() was throwing type errors.
-        for(var i = 0; i < LINKS.length; i++) { 
-            LINKS[i].style.color = "#bac0ce";
-        };
     }
     else if (BODY.classList.contains("dk-grey-bg")) {
         BODY.classList.replace("dk-grey-bg", "grey-bg");
-        // This is the only way I could get links to be syled. links.classList.add() was throwing type errors.
-        for(var i = 0; i < LINKS.length; i++) { 
-            LINKS[i].style.color = "#61656e";
-        }
     };
 }
 


### PR DESCRIPTION
Instead of looping through all links on the page when dark mode is toggled, we can just use CSS to change the link colors.

This also means that the color does not need to be hard-coded in the JS, but can live in the SASS where it belongs. Separation of style and logic for the win :tada: